### PR TITLE
Give a more meaningful error when the encoderfile config is not present

### DIFF
--- a/encoderfile/Cargo.toml
+++ b/encoderfile/Cargo.toml
@@ -52,6 +52,11 @@ path = "tests/integration/test_build.rs"
 required-features = ["dev-utils"]
 
 [[test]]
+name = "test_config_does_not_exist"
+path = "tests/integration/test_config_does_not_exist.rs"
+required-features = ["dev-utils"]
+
+[[test]]
 name = "test_inspect_encoderfile"
 path = "tests/integration/test_inspect.rs"
 required-features = ["dev-utils"]

--- a/encoderfile/src/build_cli/config.rs
+++ b/encoderfile/src/build_cli/config.rs
@@ -22,8 +22,13 @@ pub struct BuildConfig {
     pub encoderfile: EncoderfileConfig,
 }
 
+pub const CONFIG_FILE_NOT_FOUND_MSG: &str = "Encoderfile config not found";
+
 impl BuildConfig {
     pub fn load(path: &PathBuf) -> Result<Self> {
+        if !path.try_exists().expect(CONFIG_FILE_NOT_FOUND_MSG) {
+            bail!(CONFIG_FILE_NOT_FOUND_MSG);
+        }
         let config = Figment::new().merge(Yaml::file(path)).extract()?;
 
         Ok(config)

--- a/encoderfile/tests/integration/test_config_does_not_exist.rs
+++ b/encoderfile/tests/integration/test_config_does_not_exist.rs
@@ -1,0 +1,30 @@
+use anyhow::{Context, Result};
+use encoderfile::build_cli::cli::GlobalArguments;
+use encoderfile::build_cli::config::CONFIG_FILE_NOT_FOUND_MSG;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn test_config_does_not_exist() -> Result<()> {
+    let dir = tempdir()?;
+    let path = dir
+        .path()
+        .canonicalize()
+        .expect("Failed to canonicalize temp path")
+        .join("encoderfile_does_not_exist.yml");
+
+    let build_args = encoderfile::build_cli::cli::test_build_args(
+        path.as_path(),
+        Path::new("dummy_binary_path"),
+    );
+
+    let global_args = GlobalArguments::default();
+
+    let build_result = build_args
+        .run(&global_args)
+        .context("Failed to build encoderfile");
+    assert!(build_result.is_err());
+    build_result.expect_err(CONFIG_FILE_NOT_FOUND_MSG);
+
+    Ok(())
+}


### PR DESCRIPTION
When the encoderfile is not present, the previous error message pointed at missing yaml properties. Now this condition is detected before yaml parsing, and reported using a specific error message.

Closes #274 