### PR TITLE
Fix hf auth when the HF_TOKEN var is not used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 setup:
 	@echo "logging to hf..."
 	@curl -LsSf https://hf.co/cli/install.sh | bash
-	@echo ${#HF_TOKEN}
-	@hf auth login --token $(HF_TOKEN)
+	@echo $${#HF_TOKEN}
+	@hf auth login $${HF_TOKEN:+--token $${HF_TOKEN}}
 	@echo "creating .venv..."
 	@uv sync --locked
 	@echo "downloading test models..."


### PR DESCRIPTION
The hf command can use a token from its files, if an HF_TOKEN is not set. The previous form of the command in make left a dangling `--token` param if this var was missing.

Closes #278 