### PR TITLE
Add simple pytests

### DIFF
--- a/encoderfile-py/python/tests/assets/test_config.yml
+++ b/encoderfile-py/python/tests/assets/test_config.yml
@@ -1,11 +1,8 @@
 encoderfile:
-  name: my-model-2-lua
-  path: models/dummy_electra_token_classifier
+  name: my-model-2
+  path: models/token_classification
   model_type: token_classification
-  output_path: ./test-model-lua.encoderfile
-  lua_libs:
-    - table
-    - math
+  output_path: ./test-model.encoderfile
   transform: |
     --- Applies a softmax across token classification logits.
     --- Each token classification is normalized independently.

--- a/encoderfile-py/python/tests/assets/test_config_lua.yml
+++ b/encoderfile-py/python/tests/assets/test_config_lua.yml
@@ -1,0 +1,23 @@
+encoderfile:
+  name: my-model-2-lua
+  path: models/token_classification
+  model_type: token_classification
+  output_path: ./test-model.encoderfile
+  lua_libs:
+    - table
+    - math
+  transform: |
+    --- Applies a softmax across token classification logits.
+    --- Each token classification is normalized independently.
+    --- 
+    --- Args:
+    ---   arr (Tensor): A tensor of shape [batch_size, n_tokens, n_labels].
+    ---                 The softmax is applied along the third axis (n_labels).
+    ---
+    --- Returns:
+    ---   Tensor: The input tensor with softmax-normalized embeddings.
+    ---@param arr Tensor
+    ---@return Tensor
+    function Postprocess(arr)
+        return arr:softmax(3)
+    end

--- a/encoderfile-py/python/tests/conftest.py
+++ b/encoderfile-py/python/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+
+import yaml
+
+
+def asset_path(filename: str) -> str:
+    """
+    Returns the absolute path to an asset file in the assets directory,
+    regardless of the current working directory.
+    """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(base_dir, "assets", filename)
+
+
+def load_yaml_asset(filename):
+    """
+    Loads a yaml asset file from the assets directory.
+    """
+    path = asset_path(filename)
+    if filename.endswith((".yml", ".yaml")):
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    else:
+        raise ValueError("Only yaml files are supported for this fixture.")

--- a/encoderfile-py/python/tests/test_all.py
+++ b/encoderfile-py/python/tests/test_all.py
@@ -1,5 +1,0 @@
-# import encoderfile as ef
-
-
-def test_todo():
-    assert True

--- a/encoderfile-py/python/tests/test_encoderfile_stub.py
+++ b/encoderfile-py/python/tests/test_encoderfile_stub.py
@@ -1,0 +1,38 @@
+import pytest
+from encoderfile import (
+    EncoderfileBuilder,
+    ModelConfig,
+    EncoderfileConfig,
+    InspectInfo,
+    inspect,
+)
+from conftest import asset_path, load_yaml_asset
+
+
+def test_encoderfilebuilder_from_config_returns_builder():
+    config_path = asset_path("test_config.yml")
+    builder = EncoderfileBuilder.from_config(config_path)
+    assert isinstance(builder, EncoderfileBuilder)
+
+
+@pytest.mark.parametrize("config_filename", ["test_config.yml", "test_config_lua.yml"])
+def test_encoderfilebuilder_build_runs(config_filename):
+    config_path = asset_path(config_filename)
+    config_info = load_yaml_asset(config_filename)
+    builder = EncoderfileBuilder.from_config(config_path)
+    # Should not raise
+    builder.build(working_dir=None, version=None, no_download=True)
+    result = inspect(config_info["encoderfile"]["output_path"])
+    assert isinstance(result, InspectInfo)
+    assert isinstance(result.model_config, ModelConfig)
+    assert isinstance(result.encoderfile_config, EncoderfileConfig)
+    print(result.model_config)
+    print(result.encoderfile_config)
+    assert result.encoderfile_config.name == config_info["encoderfile"]["name"]
+    assert (
+        result.encoderfile_config.transform.strip()
+        == config_info["encoderfile"].get("transform").strip()
+    )
+    assert result.encoderfile_config.lua_libs == config_info["encoderfile"].get(
+        "lua_libs"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [ "pip>=25.2", "protobuf>=6.33.0"]
 
 [dependency-groups]
-dev = [ "pre-commit>=4.3.0", "ruff>=0.14.2", "mypy>=1.19"]
+dev = [ "pre-commit>=4.3.0", "ruff>=0.14.2", "mypy>=1.19", "pytest"]
 docs = [ "mkdocs>=1.6.1", "mkdocs-include-markdown-plugin>=7.2.0", "mkdocs-material>=9.7.0",]
 setup = [ "onnxruntime>=1.23.1", "optimum[onnxruntime]>=2.0.0", "transformers>=4.55.0",]
 models = [ "torch>=2.9.0", "click", {include-group = "setup"} ]

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 docs = [
@@ -207,6 +208,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.19" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest" },
     { name = "ruff", specifier = ">=0.14.2" },
 ]
 docs = [


### PR DESCRIPTION
A couple of simple tests that build and inspect the generated encoderfiles using the python API have been added. They still need to be added, together with the stubtest checks, into the overall pre-commit action.