### PR TITLE
fix: include ca-certificates and curl on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,12 @@ FROM debian:bookworm-slim AS final
 # Default working directory.
 WORKDIR /opt/encoderfile
 
+#  ca-certificates for downloading base binaries
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install binary into a standard PATH location.
 COPY --from=build /app/target/release/encoderfile /usr/local/bin/encoderfile
 


### PR DESCRIPTION
Should be included as a dependency for downloading encoderfile base binaries