### PR TITLE
Hide rust module

### DIFF
--- a/encoderfile-py/Cargo.toml
+++ b/encoderfile-py/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "_encoderfile_rust"
+name = "_core"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/encoderfile-py/pyproject.toml
+++ b/encoderfile-py/pyproject.toml
@@ -25,4 +25,4 @@ Homepage = "https://mozilla-ai.github.io/encoderfile"
 
 [tool.maturin]
 python-source = "python"
-module-name = "encoderfile._encoderfile_rust" 
+module-name = "encoderfile._core" 

--- a/encoderfile-py/python/encoderfile/__init__.py
+++ b/encoderfile-py/python/encoderfile/__init__.py
@@ -1,9 +1,7 @@
 # type: ignore
-from ._encoderfile_rust import *  # noqa: F403
+from ._core import *  # noqa: F403
 from .enums import *  # noqa: F403
 
-__doc__ = _encoderfile_rust.__doc__  # noqa: F405
-if hasattr(_encoderfile_rust, "__all__"):  # noqa: F405
-    __all__ = _encoderfile_rust.__all__  # noqa: F405
-
-del _encoderfile_rust  # noqa: F821
+__doc__ = _core.__doc__  # noqa: F405
+if hasattr(_core, "__all__"):  # noqa: F405
+    __all__ = _core.__all__  # noqa: F405

--- a/encoderfile-py/src/lib.rs
+++ b/encoderfile-py/src/lib.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 mod builder;
 
 /// A Python module implemented in Rust.
-#[pymodule(name = "_encoderfile_rust")]
+#[pymodule(name = "_core")]
 mod encoderfile {
     #[pymodule_export]
     use super::builder::PyTargetSpec;


### PR DESCRIPTION
The rust module has a hidden (_) name under the top module encoderfile. Furthermore, after importing the definitions the submodule entry is deleted. The pytest and stubtest tests both pass. @besaleli Wdyt?

Closes #298 