### PR TITLE
docs: Add Local RAG and CVE Search cookbook entries

### DIFF
--- a/docs/cookbooks/local-rag.md
+++ b/docs/cookbooks/local-rag.md
@@ -1,0 +1,11 @@
+# Local RAG with Encoderfile + Llamafile
+
+A fully local RAG (Retrieval-Augmented Generation) system. Give it any text file, ask it questions. Everything stays local.
+
+- **Encoderfile** handles embedding locally. 
+- **Llamafile** runs the LLM locally. 
+- **NumPy** handles similarity search in memory.
+
+This is a good fit for offline environments, sensitive documents, or anywhere you need a simple, self-contained question-answering system without cloud dependencies.
+
+Check out the full code and instructions in [GitHub](https://github.com/mozilla-ai/encoderfile/tree/main/examples/local-rag).

--- a/docs/cookbooks/qdrant-cve-search.md
+++ b/docs/cookbooks/qdrant-cve-search.md
@@ -1,0 +1,7 @@
+# CVE Semantic Search with Encoderfile + Qdrant
+
+A fully local, privacy-first vulnerability search system. Embed CVE descriptions with Encoderfile, store and search them with Qdrant — all self-hosted, no data leaves your network.
+
+This is a good fit for internal security teams that need natural language search for vulnerability reports, pen test findings, or bug bounty submissions where sending data to a cloud embedding API is not an option.
+
+Check out the full code and instructions in [GitHub](https://github.com/mozilla-ai/encoderfile/tree/main/examples/qdrant_cve_search).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,8 @@ nav:
       - Token Classification (NER): cookbooks/token-classification-ner.md
       - MCP Integration: cookbooks/mcp-integration.md
       - Matryoshka Embeddings: cookbooks/matryoshka-embeddings.md
+      - Local RAG: cookbooks/local-rag.md
+      - CVE Semantic Search: cookbooks/qdrant-cve-search.md
   - Code of Conduct: CODE_OF_CONDUCT.md
   - Contributing: CONTRIBUTING.md
   - Transforms:


### PR DESCRIPTION
Adds thin cookbook pages for the local-rag and qdrant_cve_search examples and registers both in the mkdocs.yml nav.