### PR TITLE
Replace `platform` with `target` for triples params

### DIFF
--- a/docs/reference/file_format.md
+++ b/docs/reference/file_format.md
@@ -26,12 +26,12 @@ Base binaries are built in a `debian:bookworm` image and are compatible with gli
 
 ### Cross-compilation & Custom Base Binaries
 
-Pre-built binaries make cross-compilation for major platforms and operating systems trivial. When building encoderfiles, just specify which platform you want to build the encoderfile for with the `--platform` argument. For example:
+Pre-built binaries make cross-compilation for major platforms and operating systems trivial. When building encoderfiles, just specify which platform you want to build the encoderfile for with the `--target` argument. For example:
 
 ```bash
 encoderfile build \
     -f encoderfile.yml \
-    --platform x86_64-unknown-linux-gnu
+    --target x86_64-unknown-linux-gnu
 ```
 
 Platform identifiers use Rust target triples. If you do not specify a platform identifier, encoderfile CLI will auto-detect your machine's architecture and download its corresponding base binary (if not already cached).

--- a/encoderfile/src/builder/cli/build.rs
+++ b/encoderfile/src/builder/cli/build.rs
@@ -22,10 +22,10 @@ pub struct BuildArgs {
     )]
     pub base_binary_path: Option<PathBuf>,
     #[arg(
-        long = "platform",
+        long = "target",
         help = "Target platform to build. Follows standard rust target triple format."
     )]
-    pub platform: Option<TargetSpec>,
+    pub target: Option<TargetSpec>,
     #[arg(
         long,
         help = "Encoderfile version override (defaults to current version)."
@@ -71,8 +71,8 @@ impl BuildArgs {
             config.encoderfile.base_binary_path = Some(base_binary_path.to_path_buf());
         }
 
-        if let Some(platform) = &self.platform {
-            config.encoderfile.target = Some(platform.clone());
+        if let Some(target) = &self.target {
+            config.encoderfile.target = Some(target.clone());
         }
 
         super::super::builder::EncoderfileBuilder::new(config)
@@ -89,7 +89,7 @@ pub fn test_build_args(
         config: config.into(),
         output_path: None,
         base_binary_path: Some(base_binary_path.into()),
-        platform: None,
+        target: None,
         version: None,
         no_download: true,
         working_dir: None,
@@ -106,7 +106,7 @@ pub fn test_build_args_working_dir(
         config: config.into(),
         output_path: None,
         base_binary_path: Some(base_binary_path.into()),
-        platform: None,
+        target: None,
         version: None,
         no_download: true,
         working_dir: Some(working_dir.into()),


### PR DESCRIPTION
The `platform` parameter will be replaced with `target` wherever it is used to align with the usage in the rust commands. 

Closes #383 